### PR TITLE
Fixed search-to-show-link path

### DIFF
--- a/app/views/tablescapes/search_results.html.erb
+++ b/app/views/tablescapes/search_results.html.erb
@@ -16,7 +16,7 @@
                  </div>
               </div>
               <p class="card-text"><%= t.description %></p>
-              <%= link_to "See details", root_path, class: "btn btn-success btn-details"%>
+              <%= link_to "See details", tablescape_path(t), class: "btn btn-success btn-details"%>
               </div>
             </div>
           <% end %>


### PR DESCRIPTION
Fixed the link in the button for the search page item to show page item. Please review and merge. 