### PR TITLE
Fixed bug in link to tablescape showpage"

### DIFF
--- a/app/views/tablescapes/show.html.erb
+++ b/app/views/tablescapes/show.html.erb
@@ -21,7 +21,7 @@
         </div>
     <% else %>
 
-      <img src="<%= tablescape.image %>" class="main-image" alt="">
+      <img src="<%= @tablescape.image %>" class="main-image" alt="">
     <% end %>
     <div class="tablescape-description">
       <h2><%=  @tablescape.name%></h2>


### PR DESCRIPTION
Fixed 'tablescape' to '@tabelscape' in the the show tablescape page.